### PR TITLE
2025/04/28 機能追加・変更

### DIFF
--- a/EmployeeManagementSystem/AddEmployeeInfoForm.cs
+++ b/EmployeeManagementSystem/AddEmployeeInfoForm.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using System.Xml.Linq;
 using EmployeeManagementSystem.Contexts;
 using EmployeeManagementSystem.DataModel;
+using EmployeeManagementSystem.Utils;
 
 namespace EmployeeManagementSystem
 {
@@ -45,8 +46,8 @@ namespace EmployeeManagementSystem
             {
                 // 確認ダイアログを表示
                 DialogResult result = MessageBox.Show(
-                    "本当にキャンセルしてもよろしいですか？",
-                    "確認",
+                    InformationMessages.INFO003_CANCEL_CONFIRMATION,
+                    InformationMessages.TITLE001_CONFIRMATION,
                     MessageBoxButtons.YesNo, // YesとNoボタンを表示
                     MessageBoxIcon.Warning  // 警告アイコンを表示
                 );
@@ -73,19 +74,19 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtKanaFirstName.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, "姓（かな）は入力必須です。");
+                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR004_MISSING_KANA_FIRST_NAME);
                 isValid = false;
             }
             else if (txtKanaFirstName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, "姓（かな）は25文字以内で入力してください。");
+                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR002_KANA_FIRST_NAME_LIMIT);
                 isValid = false;
             }
             else if (!System.Text.RegularExpressions.Regex.IsMatch(txtKanaFirstName.Text, @"^[\u3041-\u3096ー]+$"))
             {
                 // 平仮名以外が含まれている場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, "平仮名のみ入力してください。");
+                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR003_INPUT_HIRAGANA_ONLY);
                 isValid = false;
             }
             else
@@ -98,19 +99,19 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtKanaLastName.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtKanaLastName, "名（かな）は入力必須です。");
+                errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR006_MISSING_KANA_LAST_NAME);
                 isValid = false;
             }
             else if (txtKanaFirstName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, "名（かな）は25文字以内で入力してください。");
+                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR005_KANA_LAST_NAME_LIMIT);
                 isValid = false;
             }
             else if (!System.Text.RegularExpressions.Regex.IsMatch(txtKanaLastName.Text, @"^[\u3041-\u3096ー]+$"))
             {
                 // 平仮名以外が含まれている場合のエラー設定
-                errorProvider.SetError(txtKanaLastName, "平仮名のみ入力してください。");
+                errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR003_INPUT_HIRAGANA_ONLY);
                 isValid = false;
             }
             else
@@ -123,13 +124,13 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtFirstName.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtFirstName, "姓 は入力必須です。");
+                errorProvider.SetError(txtFirstName, ErrorMessages.ERR008_MISSING_FIRST_NAME);
                 isValid = false;
             }
             else if (txtFirstName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtFirstName, "姓 は25文字以内で入力してください。");
+                errorProvider.SetError(txtFirstName, ErrorMessages.ERR007_FIRST_NAME_LIMIT);
                 isValid = false;
             }
             else
@@ -142,13 +143,13 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtLastName.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtLastName, "名 は入力必須です。");
+                errorProvider.SetError(txtLastName, ErrorMessages.ERR010_MISSING_LAST_NAME);
                 isValid = false;
             }
             else if (txtLastName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtLastName, "名 は25文字以内で入力してください。");
+                errorProvider.SetError(txtLastName, ErrorMessages.ERR009_LAST_NAME_LIMIT);
                 isValid = false;
             }
             else
@@ -161,12 +162,12 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtMail.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtMail, "メールアドレス は入力必須です。");
+                errorProvider.SetError(txtMail, ErrorMessages.ERR011_MISSING_MAIL);
                 isValid = false;
             }
-            else if (!System.Text.RegularExpressions.Regex.IsMatch(txtMail.Text, @"^[^@\s]+@[^@\s]+\.[^@\s]+$"))
+            else if (!System.Text.RegularExpressions.Regex.IsMatch(txtMail.Text, @"^[a-zA-Z][a-zA-Z0-9._-]*@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"))
             {
-                errorProvider.SetError(txtMail, "有効なメールアドレスを入力してください。");
+                errorProvider.SetError(txtMail, ErrorMessages.ERR012_REQUIRED_VALID_MAIL);
                 isValid = false;
             }
             else
@@ -179,12 +180,12 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(txtPhoneNum.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(txtPhoneNum, "電話番号 は入力必須です。");
+                errorProvider.SetError(txtPhoneNum, ErrorMessages.ERR013_MISSING_PHONE_NUM);
                 isValid = false;
             }
             else if (!System.Text.RegularExpressions.Regex.IsMatch(txtPhoneNum.Text, @"^\d{2,4}-\d{2,4}-\d{4}$"))
             {
-                errorProvider.SetError(txtPhoneNum, "電話番号は「080-1234-5678」の形式で入力してください。");
+                errorProvider.SetError(txtPhoneNum, ErrorMessages.ERR014_REQUIRED_VALID_PHONE_NUM);
                 isValid = false;
             }
             else
@@ -197,7 +198,7 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(selectOffice.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(selectOffice, "拠点 は入力必須です。");
+                errorProvider.SetError(selectOffice, ErrorMessages.ERR015_MISSING_OFFICE);
                 isValid = false;
             }
             else
@@ -210,7 +211,7 @@ namespace EmployeeManagementSystem
             if (string.IsNullOrEmpty(selectPosition.Text))
             {
                 // 空欄の場合のエラー設定
-                errorProvider.SetError(selectPosition, "役職 は入力必須です。");
+                errorProvider.SetError(selectPosition, ErrorMessages.ERR017_MISSING_POSITION);
                 isValid = false;
             }
             else
@@ -226,7 +227,7 @@ namespace EmployeeManagementSystem
             if (selectedDate >= DateTime.Now)
             {
                 // エラーメッセージとエラーアイコンを設定
-                errorProvider.SetError(selectHireDate, "日付は現在以前である必要があります。");
+                errorProvider.SetError(selectHireDate, ErrorMessages.ERR021_DATE_MUST_BE_PAST_OR_PRESENT);
                 isValid = false;
             }
             else
@@ -283,7 +284,7 @@ namespace EmployeeManagementSystem
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"データの読み込み中にエラーが発生しました: {ex.Message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show($"{ErrorMessages.ERR019_DATABASE_READ_ERROR} {ex.Message}", InformationMessages.TITLE002_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -295,52 +296,64 @@ namespace EmployeeManagementSystem
                 // 入力内容を検証
                 if (!ValidateInput())
                 {
-                    MessageBox.Show("入力エラーがあります。修正してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBox.Show(ErrorMessages.ERR026_HAVING_INPUT_ERROR, InformationMessages.TITLE004_INPUT_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return;
                 }
 
-                try
+                // 確認ダイアログを表示
+                DialogResult result = MessageBox.Show(
+                    InformationMessages.INFO009_ADD_CONFIRMATION,
+                    InformationMessages.TITLE001_CONFIRMATION,
+                    MessageBoxButtons.YesNo, // YesとNoボタンを表示
+                    MessageBoxIcon.Warning  // 警告アイコンを表示
+                );
+
+                // ダイアログの結果に基づいて処理
+                if (result == DialogResult.Yes)
                 {
-                    // Office ID を取得
-                    var selectedOfficeName = selectOffice.SelectedItem?.ToString();
-                    var officeId = dbContext.Office
-                        .Where(o => o.office_name == selectedOfficeName)
-                        .Select(o => o.office_id)
-                        .FirstOrDefault();
-
-                    // Position ID を取得
-                    var selectedPositionName = selectPosition.SelectedItem?.ToString();
-                    var positionId = dbContext.Position
-                        .Where(p => p.position_name == selectedPositionName)
-                        .Select(p => p.position_id)
-                        .FirstOrDefault();
-
-                    // 新しい社員情報を作成
-                    var newEmployee = new EmployeeModel
+                    try
                     {
-                        kana_first_name = txtKanaFirstName.Text,
-                        kana_last_name = txtKanaLastName.Text,
-                        first_name = txtFirstName.Text,
-                        last_name = txtLastName.Text,
-                        mail = txtMail.Text,
-                        phone_num = txtPhoneNum.Text,
-                        hire_date = selectHireDate.Value, // DateTimePicker から日付を取得
-                        office_id = officeId,
-                        position_id = positionId,
-                        status = 1 //在職中で登録する
-                    };
+                        // Office ID を取得
+                        var selectedOfficeName = selectOffice.SelectedItem?.ToString();
+                        var officeId = dbContext.Office
+                            .Where(o => o.office_name == selectedOfficeName)
+                            .Select(o => o.office_id)
+                            .FirstOrDefault();
 
-                    // データベースに追加
-                    dbContext.Employee.Add(newEmployee);
-                    dbContext.SaveChanges();
+                        // Position ID を取得
+                        var selectedPositionName = selectPosition.SelectedItem?.ToString();
+                        var positionId = dbContext.Position
+                            .Where(p => p.position_name == selectedPositionName)
+                            .Select(p => p.position_id)
+                            .FirstOrDefault();
 
-                    MessageBox.Show("データが正常に保存されました。", "保存成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    this.Close();
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show($"データの保存中にエラーが発生しました: {ex.Message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                        // 新しい社員情報を作成
+                        var newEmployee = new EmployeeModel
+                        {
+                            kana_first_name = txtKanaFirstName.Text,
+                            kana_last_name = txtKanaLastName.Text,
+                            first_name = txtFirstName.Text,
+                            last_name = txtLastName.Text,
+                            mail = txtMail.Text,
+                            phone_num = txtPhoneNum.Text,
+                            hire_date = selectHireDate.Value, // DateTimePicker から日付を取得
+                            office_id = officeId,
+                            position_id = positionId,
+                            status = 1 //在職中で登録する
+                        };
+
+                        // データベースに追加
+                        dbContext.Employee.Add(newEmployee);
+                        dbContext.SaveChanges();
+
+                        MessageBox.Show(InformationMessages.INFO010_SAVE_SUCCESS, InformationMessages.TITLE009_SAVED, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        this.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"{ErrorMessages.ERR030_DATA_SAVE_ERROR} {ex.Message}", InformationMessages.TITLE002_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }                    
             }
         }
 
@@ -358,6 +371,17 @@ namespace EmployeeManagementSystem
             // コンボボックスの選択をクリア
             selectOffice.SelectedIndex = -1; // 拠点
             selectPosition.SelectedIndex = -1; // 役職
+
+            // エラーをクリア
+            errorProvider.SetError(txtKanaFirstName, string.Empty);
+            errorProvider.SetError(txtKanaLastName, string.Empty);
+            errorProvider.SetError(txtFirstName, string.Empty);
+            errorProvider.SetError(txtLastName, string.Empty);
+            errorProvider.SetError(txtMail, string.Empty);
+            errorProvider.SetError(txtPhoneNum, string.Empty);
+            errorProvider.SetError(selectHireDate, string.Empty);
+            errorProvider.SetError(selectOffice, string.Empty);
+            errorProvider.SetError(selectPosition, string.Empty);
         }
     }
 }

--- a/EmployeeManagementSystem/Contexts/EmployeeManagementSystemContext.cs
+++ b/EmployeeManagementSystem/Contexts/EmployeeManagementSystemContext.cs
@@ -21,6 +21,7 @@ namespace EmployeeManagementSystem.Contexts
         public DbSet<OperatorModel> Operator { get; set; } // Operation テーブル
         public DbSet<PositionModel> Position { get; set; } // Position テーブル
         public DbSet<OfficeModel> Office { get; set; } // Office テーブル
+        public DbSet<SessionModel> Session { get; set; } //Session テーブル
         public DbSet<EmployeeView> EmployeeView { get; set; }
 
 
@@ -44,18 +45,29 @@ namespace EmployeeManagementSystem.Contexts
                 .HasKey(op => op.operator_id); // Operatorテーブルの主キー
             modelBuilder.Entity<OperatorModel>()
                 .HasOne(op => op.EmployeeIdNavigation) // 外部キーとしてEmployeeIdを指定
-                .WithMany(e => e.Operators)
+                .WithMany(e => e.Operator)
                 .HasForeignKey(op => op.employee_id); // OperatorModelとEmployeeModelのリレーション
 
             // EmployeeModelの設定（スキーマ名: public, テーブル名: employee）
             modelBuilder.Entity<EmployeeModel>()
                 .ToTable("employee", "public");
 
+
+
             // EmployeeView をデータベースビューとして設定
             modelBuilder.Entity<EmployeeView>().ToView("EmployeeView"); // ビュー名を指定
 
             // EmployeeView のプライマリーキーを設定
             modelBuilder.Entity<EmployeeView>().HasKey(e => e.employee_id); // 正確なプロパティ名を使用
+
+            // SessionModelの設定（スキーマ名: public, テーブル名: session）
+            modelBuilder.Entity<SessionModel>()
+                .ToTable("session", "public")
+                .HasKey(s => s.session_id); // Sessionテーブルの主キー
+            modelBuilder.Entity<SessionModel>()
+                .HasOne(s => s.EmployeeIdNavigation) // 外部キーとしてEmployeeIdを指定
+                .WithMany(e => e.Session)
+                .HasForeignKey(s => s.employee_id); // SessionModelとEmployeeModelのリレーション
 
             // 親クラスの設定を呼び出し
             base.OnModelCreating(modelBuilder);

--- a/EmployeeManagementSystem/DataModel/EmployeeModel.cs
+++ b/EmployeeManagementSystem/DataModel/EmployeeModel.cs
@@ -50,7 +50,9 @@ namespace EmployeeManagementSystem.DataModel
 
 
 
-        public ICollection<OperatorModel> Operators { get; set; } = new List<OperatorModel>(); //OperatorModel とのリレーション (1対多)
+        public ICollection<OperatorModel> Operator { get; set; } = new List<OperatorModel>(); //OperatorModel とのリレーション (1対多)
+
+        public ICollection<SessionModel> Session { get; set; } = new List<SessionModel>(); //SessionModel とのリレーション (1対多)
 
     }
 }

--- a/EmployeeManagementSystem/DataModel/SessionModel.cs
+++ b/EmployeeManagementSystem/DataModel/SessionModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmployeeManagementSystem.DataModel
+{
+    public class SessionModel
+    {
+        
+        public int session_id { get; set; } // セッションID（主キー）
+        
+        public int employee_id { get; set; } // 社員ID（外部キー）
+        
+        public DateTime login_time { get; set; } // ログイン時間
+        
+        public DateTime? logout_time { get; set; } // ログアウト時間（null可能）
+        
+        public string session_token { get; set; } // セッショントークン
+        
+        public string ip_address { get; set; } // IPアドレス
+      
+        public string user_agent { get; set; } // ブラウザ・デバイス情報
+
+        public bool is_active { get; set; } // アクティブ状態（1: アクティブ, 0: 非アクティブ）
+
+
+
+        public required EmployeeModel EmployeeIdNavigation { get; set; }
+    }
+}

--- a/EmployeeManagementSystem/LoginForm.Designer.cs
+++ b/EmployeeManagementSystem/LoginForm.Designer.cs
@@ -59,6 +59,7 @@
             resources.ApplyResources(txtPassword, "txtPassword");
             txtPassword.BorderStyle = BorderStyle.FixedSingle;
             txtPassword.Name = "txtPassword";
+            txtPassword.UseSystemPasswordChar = true;
             // 
             // btnLogin
             // 
@@ -86,7 +87,8 @@
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             Controls.Add(panelLogin);
-            FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
             Name = "LoginForm";
             panelLogin.ResumeLayout(false);
             panelLogin.PerformLayout();

--- a/EmployeeManagementSystem/LoginForm.cs
+++ b/EmployeeManagementSystem/LoginForm.cs
@@ -1,105 +1,231 @@
 using EmployeeManagementSystem.Contexts;
+using EmployeeManagementSystem.DataModel;
+using EmployeeManagementSystem.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MySqlConnector;
+using System.Collections.Generic;
+using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace EmployeeManagementSystem
 {
     public partial class LoginForm : Form
     {
+        //該当エラーメッセージリスト
+        List<string> errorMessages = new List<string>();
+
         public LoginForm()
         {
             InitializeComponent();
-            // フォームサイズを固定
-            this.ClientSize = new Size(1000, 800); // 横1000, 縦800
-            this.FormBorderStyle = FormBorderStyle.FixedDialog; // サイズ変更を無効化
-            this.MaximizeBox = false; // 最大化ボタンを無効化
-            this.StartPosition = FormStartPosition.CenterScreen; // 画面中央に表示
-
-            // パスワード入力ボックスの設定（マスキング）
-            txtPassword.UseSystemPasswordChar = true;
 
             // ボタンクリックイベント
-            btnLogin.Click += (s, e) =>
+            btnLogin.Click += btnLogin_click;
+
+
+        }
+
+        private void btnLogin_click(object sender, EventArgs e)
+        {
             {
                 // 入力値を取得
                 string inputMail = txtMail.Text;
                 string inputPassword = txtPassword.Text;
 
-                // 入力検証: 空の場合はエラーメッセージを表示
-                if (string.IsNullOrEmpty(inputMail) || string.IsNullOrEmpty(inputPassword))
+                errorMessages = IsValidInput(inputPassword, inputMail);
+
+                if (errorMessages == null || !errorMessages.Any())
                 {
-                    MessageBox.Show("メールアドレスとパスワードを入力してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    using (var dbContext = new EmployeeManagementSystemContext())
+                    {
+                        try
+                        {
+                            // メールアドレスとパスワードで検索
+                            var operatorRecord = dbContext.Operator
+                                .Join(dbContext.Employee,
+                                      op => op.employee_id, // operatorテーブルの結合キー
+                                      e => e.employee_id, // employeeテーブルの結合キー
+                                      (op, e) => new { Operator = op, Mail = e.mail }) // 必要なデータをプロジェクション
+                                .Where(record => record.Mail == inputMail && record.Operator.password == inputPassword) // 条件指定
+                                .FirstOrDefault(); // 最初のレコードを取得
+
+
+
+                            // SQLログを取得
+                            //string logs = dbContext.GetLogs();
+
+                            // メッセージボックスにログを表示
+                            //MessageBox.Show(!string.IsNullOrEmpty(logs) ? logs : "ログがありません", "生成されたSQLログ", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+
+                            if (operatorRecord != null)
+                            {
+                                // 認証成功
+
+                                //セッション情報の作成
+                                int employeeId = operatorRecord.Operator.employee_id;
+                                String session_token = CreateSession(employeeId);
+                                
+                                if(session_token != null)
+                                {
+                                    SessionModel sessionData = GetSessionRecordData(session_token);
+                                    SetSession(sessionData);
+                                    SessionManager.StartSession(); // セッションを開始
+                                    Clear_Inputs();
+                                    ShowEmployeeInfoForm showEmployeeInfoForm = new ShowEmployeeInfoForm(this);
+                                    showEmployeeInfoForm.Show();
+                                    this.Hide(); // ログインフォームを非表示
+
+                                }                                
+                            }
+                            else
+                            {
+                                // 認証失敗
+                                MessageBox.Show(ErrorMessages.ERR022_REQUIRED_VALID_PASSWORD_AND_MAIL, InformationMessages.TITLE010_AUTHENTICATION_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // 例外処理
+                            MessageBox.Show($"{ErrorMessages.ERR019_DATABASE_READ_ERROR} {ex.Message}", InformationMessages.TITLE002_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        }
+                    }
+                }
+                else
+                {
+                    DisplayErrorMessages(errorMessages);
                     return;
                 }
-                
-                using (var dbContext = new EmployeeManagementSystemContext())
+            }
+        }
+
+        private List<String> IsValidInput(String password, String mail)
+        {
+            List<string> isValidInput_ErrorMessages = new List<string>();
+
+            // 入力検証: 空の場合はエラーメッセージを表示
+            if (string.IsNullOrEmpty(mail) || string.IsNullOrEmpty(password))
+            {
+                isValidInput_ErrorMessages.Add(ErrorMessages.ERR022_MISSING_PASSWORD_AND_MAIL);
+            }
+            //メールアドレスが正しく入力されているか
+            else if (!System.Text.RegularExpressions.Regex.IsMatch(mail, @"^[a-zA-Z][a-zA-Z0-9._-]*@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"))
+            {
+                isValidInput_ErrorMessages.Add(ErrorMessages.ERR012_REQUIRED_VALID_MAIL);
+            }
+
+            return isValidInput_ErrorMessages;
+        }
+
+        private void DisplayErrorMessages(List<string> errorMessages)
+        {
+            // エラーメッセージを改行で区切って結合
+            String messages = string.Join(Environment.NewLine, errorMessages);
+            MessageBox.Show(messages, InformationMessages.TITLE004_INPUT_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+        }
+
+
+        internal void Clear_Inputs()
+        {
+            txtMail.Text = null;
+            txtPassword.Text = null;
+        }
+
+        private String CreateSession(int employeeId)
+        {
+            using (var dbContext = new EmployeeManagementSystemContext())
+            {
+                try
                 {
-                    try
+                    String ip_address = GetIpAddress();
+                    String user_agent = GetUserAgent();
+                    String session_token = Guid.NewGuid().ToString();
+                    DateTime login_time = DateTime.Now;
+
+                    // 新しいセッションを作成
+                    var newSession = new SessionModel
                     {
+                        employee_id = employeeId,
+                        login_time = login_time,
+                        session_token = session_token,
+                        ip_address = ip_address, // IPアドレスの取得メソッド
+                        user_agent = user_agent, // UserAgentの取得メソッド
+                        EmployeeIdNavigation = dbContext.Employee.FirstOrDefault(e => e.employee_id == employeeId)
+                    };
 
-                        // メールアドレスとパスワードで検索
-                        var operatorRecord = dbContext.Operator
-                            .Join(dbContext.Employee,
-                                  op => op.employee_id, // operatorテーブルの結合キー
-                                  e => e.employee_id, // employeeテーブルの結合キー
-                                  (op, e) => new { Operator = op, Mail = e.mail }) // 必要なデータをプロジェクション
-                            .Where(record => record.Mail == inputMail && record.Operator.password == inputPassword) // 条件指定
-                            .FirstOrDefault(); // 最初のレコードを取得
+                    // データベースに追加
+                    dbContext.Session.Add(newSession);
+                    dbContext.SaveChanges();
 
-                        //var joinedData = dbContext.Operator
-                        //    .Join(dbContext.Employee,
-                        //    op => op.employee_id,
-                        //    e => e.employee_id,
-                        //    (op, e) => new { Operator = op, Mail = e.mail })
-                        //    .ToList();
-                        //MessageBox.Show($"結合されたデータ数: {joinedData.Count}",
-                        //    "デバッグ結果", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return session_token;
 
-
-
-                        //MessageBox.Show($"メール: {inputMail}, パスワード: {inputPassword}", "入力値確認", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                        //if (operatorRecord != null)
-                        //{
-                        //    MessageBox.Show($"メール: {operatorRecord.Mail}, パスワード: {operatorRecord.Operator.Password}",
-                        //        "クエリ結果確認", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                        //}
-                        //else
-                        //{
-                        //    MessageBox.Show("クエリ結果が空です。データがありません。",
-                        //        "確認結果", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        //}
-
-
-                        // SQLログを取得
-                        //string logs = dbContext.GetLogs();
-
-                        // メッセージボックスにログを表示
-                        //MessageBox.Show(!string.IsNullOrEmpty(logs) ? logs : "ログがありません", "生成されたSQLログ", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-
-                        if (operatorRecord != null)
-                        {
-                            // 認証成功
-                            //MessageBox.Show("ログイン成功しました。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                            ShowEmployeeInfoForm showEmployeeInfoForm = new ShowEmployeeInfoForm();
-                            showEmployeeInfoForm.Show();
-                            this.Hide(); // ログインフォームを非表示
-                        }
-                        else
-                        {
-                            // 認証失敗
-                            MessageBox.Show("メールアドレスまたはパスワードが正しくありません。", "認証エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // 例外処理
-                        MessageBox.Show($"エラーが発生しました: {ex.Message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
                 }
-            };
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"{ErrorMessages.ERR019_DATABASE_READ_ERROR} {ex.Message}", InformationMessages.TITLE002_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return null;
+                }
+            }
+        }
+
+        public string GetIpAddress()
+        {
+            string hostName = Dns.GetHostName(); // ホスト名を取得
+            var ipAddress = Dns.GetHostAddresses(hostName)
+                               .FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
+            return ipAddress?.ToString() ?? "不明";
+        }
+
+        public string GetUserAgent()
+        {
+            using (WebBrowser browser = new WebBrowser())
+            {
+                browser.Navigate("about:blank"); //WebBrowser コントロールを準備状態にする。
+                while (browser.ReadyState != WebBrowserReadyState.Complete)
+                {
+                    Application.DoEvents();
+                }
+
+                // User-Agentを取得
+                dynamic script = browser.Document.DomDocument;
+                return script?.parentWindow?.navigator?.userAgent ?? "不明";
+            }
+        }
+
+        private SessionModel GetSessionRecordData(String session_token)
+        {
+            using (var dbContext = new EmployeeManagementSystemContext())
+            {
+                try
+                {
+                    // メールアドレスとパスワードで検索
+                    var SessionRecord = dbContext.Session
+                        .Where(s => s.session_token == session_token) // 条件指定
+                        .FirstOrDefault(); // 最初のレコードを取得
+                        // セッションレコード取得成功
+                        return SessionRecord;
+                }
+                catch (Exception ex)
+                {
+                    // 例外処理
+                    MessageBox.Show($"{ErrorMessages.ERR019_DATABASE_READ_ERROR} {ex.Message}", InformationMessages.TITLE002_ERROR, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return null;
+                }
+            }
+        }
+
+        private void SetSession(SessionModel sessionModel)
+        {
+            SessionManager.session_id = sessionModel.session_id;
+            SessionManager.employee_id = sessionModel.employee_id;
+            SessionManager.login_time = sessionModel.login_time;
+            SessionManager.session_token = sessionModel.session_token;
+            SessionManager.ip_address = sessionModel.ip_address;
+            SessionManager.user_agent = sessionModel.user_agent;
+            SessionManager.is_active = sessionModel.is_active;
         }
     }
 }

--- a/EmployeeManagementSystem/LoginForm.ja-JP.resx
+++ b/EmployeeManagementSystem/LoginForm.ja-JP.resx
@@ -123,10 +123,14 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblMail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 81</value>
+    <value>133, 65</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblMail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="lblMail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 25</value>
+    <value>87, 20</value>
   </data>
   <data name="lblMail.Text" xml:space="preserve">
     <value>メールアドレス</value>
@@ -135,43 +139,67 @@
     <value>True</value>
   </data>
   <data name="lblPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 168</value>
+    <value>133, 134</value>
+  </data>
+  <data name="lblPassword.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
   </data>
   <data name="lblPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 25</value>
+    <value>64, 20</value>
   </data>
   <data name="lblPassword.Text" xml:space="preserve">
     <value>パスワード</value>
   </data>
   <data name="txtMail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 115</value>
+    <value>133, 92</value>
+  </data>
+  <data name="txtMail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="txtMail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 31</value>
+    <value>240, 27</value>
   </data>
   <data name="txtPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 196</value>
+    <value>133, 157</value>
+  </data>
+  <data name="txtPassword.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="txtPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
     <value>*</value>
   </data>
   <data name="txtPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 31</value>
+    <value>240, 27</value>
   </data>
   <data name="btnLogin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>356, 266</value>
+    <value>285, 213</value>
+  </data>
+  <data name="btnLogin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="btnLogin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 40</value>
+    <value>88, 32</value>
   </data>
   <data name="btnLogin.Text" xml:space="preserve">
     <value>ログイン</value>
   </data>
+  <data name="panelLogin.Location" type="System.Drawing.Point, System.Drawing">
+    <value>156, 112</value>
+  </data>
+  <data name="panelLogin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
   <data name="panelLogin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 349</value>
+    <value>519, 280</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>8, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>1000, 700</value>
+    <value>842, 553</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">

--- a/EmployeeManagementSystem/LoginForm.resx
+++ b/EmployeeManagementSystem/LoginForm.resx
@@ -117,265 +117,269 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="mail.Text" xml:space="preserve">
-    <value>メールアドレス：</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="lblPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 325</value>
   </data>
-  <data name="&gt;&gt;mail.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="btnLogin.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblMail.Parent" xml:space="preserve">
+  <data name="&gt;&gt;btnLogin.Parent" xml:space="preserve">
     <value>panelLogin</value>
+  </data>
+  <data name="&gt;&gt;mail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btn_login.Text" xml:space="preserve">
+    <value>ログイン</value>
+  </data>
+  <data name="&gt;&gt;txtMail.Parent" xml:space="preserve">
+    <value>panelLogin</value>
+  </data>
+  <data name="&gt;&gt;txtPassword.Name" xml:space="preserve">
+    <value>txtPassword</value>
   </data>
   <data name="&gt;&gt;panelLogin.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="btnLogin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+  <data name="&gt;&gt;btnLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btn_login.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;mail.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;txtPassword.Parent" xml:space="preserve">
+    <value>panelLogin</value>
   </data>
-  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMail.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lblUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 31</value>
+  <data name="&gt;&gt;btn_login.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btn_login.Name" xml:space="preserve">
     <value>btn_login</value>
   </data>
+  <data name="&gt;&gt;lblPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPassword.Parent" xml:space="preserve">
+    <value>panelLogin</value>
+  </data>
+  <data name="&gt;&gt;lblPassword.Name" xml:space="preserve">
+    <value>lblPassword</value>
+  </data>
+  <data name="txtPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>343, 325</value>
+  </data>
+  <data name="mail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>124, 25</value>
+  </data>
   <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>LoginForm</value>
+  <data name="&gt;&gt;lblUsername.Name" xml:space="preserve">
+    <value>lblUsername</value>
+  </data>
+  <data name="txtMail.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="lblMail.Location" type="System.Drawing.Point, System.Drawing">
     <value>135, 248</value>
   </data>
-  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 31</value>
-  </data>
   <data name="&gt;&gt;btn_login.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
+  <data name="password.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblPassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnLogin.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="lblUsername.Size" type="System.Drawing.Size, System.Drawing">
+    <value>350, 31</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="btnLogin.Location" type="System.Drawing.Point, System.Drawing">
+    <value>494, 426</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>LoginForm</value>
+  </data>
+  <data name="&gt;&gt;txtPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUsername.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="mail.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;panelLogin.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>261, 172</value>
+  </data>
+  <data name="&gt;&gt;btnLogin.Name" xml:space="preserve">
+    <value>btnLogin</value>
+  </data>
   <data name="lblPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
+    <value>textBox1</value>
+  </data>
+  <data name="&gt;&gt;mail.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>10, 25</value>
+  </data>
+  <data name="&gt;&gt;password.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblUsername.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="btnLogin.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="mail.Text" xml:space="preserve">
+    <value>メールアドレス：</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btn_login.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtMail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelLogin.Location" type="System.Drawing.Point, System.Drawing">
+    <value>172, 140</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>778, 444</value>
+  </data>
+  <data name="&gt;&gt;panelLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;password.Name" xml:space="preserve">
+    <value>password</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="mail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="password.Location" type="System.Drawing.Point, System.Drawing">
+    <value>138, 172</value>
+  </data>
+  <data name="&gt;&gt;password.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mail.Name" xml:space="preserve">
+    <value>mail</value>
+  </data>
+  <data name="btn_login.Location" type="System.Drawing.Point, System.Drawing">
+    <value>499, 269</value>
+  </data>
+  <data name="mail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 121</value>
+  </data>
+  <data name="&gt;&gt;password.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMail.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;panelLogin.Name" xml:space="preserve">
+    <value>panelLogin</value>
+  </data>
+  <data name="&gt;&gt;txtMail.Name" xml:space="preserve">
+    <value>txtMail</value>
+  </data>
+  <data name="&gt;&gt;mail.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="txtMail.Location" type="System.Drawing.Point, System.Drawing">
     <value>343, 248</value>
   </data>
-  <data name="&gt;&gt;panelLogin.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblPassword.Parent" xml:space="preserve">
-    <value>panelLogin</value>
-  </data>
-  <data name="&gt;&gt;password.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="password.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="panelLogin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>172, 140</value>
-  </data>
-  <data name="&gt;&gt;panelLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="mail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 121</value>
-  </data>
-  <data name="&gt;&gt;password.Name" xml:space="preserve">
-    <value>password</value>
-  </data>
-  <data name="&gt;&gt;txtMail.Parent" xml:space="preserve">
-    <value>panelLogin</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="password.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;btnLogin.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="lblMail.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;mail.Name" xml:space="preserve">
-    <value>mail</value>
   </data>
   <data name="password.Text" xml:space="preserve">
     <value>パスワード：</value>
   </data>
-  <data name="&gt;&gt;txtMail.Name" xml:space="preserve">
-    <value>txtMail</value>
-  </data>
-  <data name="&gt;&gt;txtPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="password.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>261, 172</value>
-  </data>
-  <data name="&gt;&gt;password.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;btnLogin.Parent" xml:space="preserve">
-    <value>panelLogin</value>
-  </data>
-  <data name="btnLogin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>494, 426</value>
-  </data>
-  <data name="&gt;&gt;lblMail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtPassword.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>778, 444</value>
-  </data>
-  <data name="&gt;&gt;txtMail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPassword.Name" xml:space="preserve">
-    <value>txtPassword</value>
-  </data>
-  <data name="&gt;&gt;txtPassword.Parent" xml:space="preserve">
-    <value>panelLogin</value>
-  </data>
-  <data name="txtMail.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;password.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPassword.Name" xml:space="preserve">
-    <value>lblPassword</value>
-  </data>
-  <data name="mail.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;lblUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMail.Name" xml:space="preserve">
-    <value>lblMail</value>
-  </data>
-  <data name="password.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 172</value>
-  </data>
-  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblPassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblUsername.Name" xml:space="preserve">
-    <value>lblUsername</value>
-  </data>
-  <data name="&gt;&gt;lblUsername.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="btn_login.Location" type="System.Drawing.Point, System.Drawing">
-    <value>499, 269</value>
-  </data>
   <data name="panelLogin.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="mail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>10, 25</value>
+  <data name="password.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="lblUsername.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>350, 31</value>
+  </data>
+  <data name="mail.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;txtPassword.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="btn_login.Text" xml:space="preserve">
-    <value>ログイン</value>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>LoginForm</value>
   </data>
-  <data name="&gt;&gt;panelLogin.Name" xml:space="preserve">
+  <data name="&gt;&gt;lblMail.Parent" xml:space="preserve">
     <value>panelLogin</value>
-  </data>
-  <data name="txtPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 325</value>
-  </data>
-  <data name="&gt;&gt;mail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="mail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 25</value>
-  </data>
-  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="btn_login.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 34</value>
-  </data>
-  <data name="&gt;&gt;btnLogin.Name" xml:space="preserve">
-    <value>btnLogin</value>
-  </data>
-  <data name="&gt;&gt;lblUsername.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;btn_login.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="password.Size" type="System.Drawing.Size, System.Drawing">
     <value>97, 25</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>LoginForm</value>
-  </data>
-  <data name="lblPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>135, 325</value>
-  </data>
-  <data name="mail.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnLogin.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;btn_login.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="btn_login.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 34</value>
   </data>
-  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
-    <value>textBox1</value>
+  <data name="lblMail.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblUsername.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtMail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="lblUsername.Location" type="System.Drawing.Point, System.Drawing">
     <value>261, 121</value>
   </data>
-  <data name="&gt;&gt;btnLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblMail.Name" xml:space="preserve">
+    <value>lblMail</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="$this.Language" type="System.Globalization.CultureInfo, System.Private.CoreLib, Culture=neutral, PublicKeyToken=7cec85d7bea7798e">
     <value>ja-JP</value>
+  </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
 </root>

--- a/EmployeeManagementSystem/ShowEmployeeInfoDetailForm.Designer.cs
+++ b/EmployeeManagementSystem/ShowEmployeeInfoDetailForm.Designer.cs
@@ -29,6 +29,8 @@
         private void InitializeComponent()
         {
             panel1 = new Panel();
+            notifyEmployeeRetired = new TextBox();
+            btnClear = new Button();
             lblAppearHireDate = new Label();
             lblAppearEmployeeId = new Label();
             lbl = new Label();
@@ -54,7 +56,6 @@
             lblKanaFirstName = new Label();
             lblEmployeeId = new Label();
             label1 = new Label();
-            btnClear = new Button();
             panel1.SuspendLayout();
             SuspendLayout();
             // 
@@ -62,6 +63,7 @@
             // 
             panel1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             panel1.BackColor = Color.Azure;
+            panel1.Controls.Add(notifyEmployeeRetired);
             panel1.Controls.Add(btnClear);
             panel1.Controls.Add(lblAppearHireDate);
             panel1.Controls.Add(lblAppearEmployeeId);
@@ -92,8 +94,31 @@
             panel1.Margin = new Padding(0);
             panel1.Name = "panel1";
             panel1.Padding = new Padding(2);
-            panel1.Size = new Size(912, 573);
+            panel1.Size = new Size(870, 800);
             panel1.TabIndex = 0;
+            // 
+            // notifyEmployeeRetired
+            // 
+            notifyEmployeeRetired.BackColor = Color.Azure;
+            notifyEmployeeRetired.BorderStyle = BorderStyle.None;
+            notifyEmployeeRetired.Font = new Font("Yu Gothic UI", 11F, FontStyle.Bold, GraphicsUnit.Point, 128);
+            notifyEmployeeRetired.ForeColor = Color.Red;
+            notifyEmployeeRetired.Location = new Point(229, 43);
+            notifyEmployeeRetired.Margin = new Padding(2);
+            notifyEmployeeRetired.Name = "notifyEmployeeRetired";
+            notifyEmployeeRetired.Size = new Size(442, 25);
+            notifyEmployeeRetired.TabIndex = 40;
+            notifyEmployeeRetired.Visible = false;
+            // 
+            // btnClear
+            // 
+            btnClear.Location = new Point(515, 380);
+            btnClear.Margin = new Padding(2);
+            btnClear.Name = "btnClear";
+            btnClear.Size = new Size(90, 27);
+            btnClear.TabIndex = 39;
+            btnClear.Text = "クリア";
+            btnClear.UseVisualStyleBackColor = true;
             // 
             // lblAppearHireDate
             // 
@@ -396,21 +421,15 @@
             label1.TabIndex = 1;
             label1.Text = "社員詳細情報";
             // 
-            // btnClear
-            // 
-            btnClear.Location = new Point(515, 380);
-            btnClear.Margin = new Padding(2);
-            btnClear.Name = "btnClear";
-            btnClear.Size = new Size(90, 27);
-            btnClear.TabIndex = 39;
-            btnClear.Text = "クリア";
-            btnClear.UseVisualStyleBackColor = true;
-            // 
             // ShowEmployeeInfoDetailForm
             // 
+            
+            ClientSize = new Size(870, 800); // フォームサイズを固定
+            FormBorderStyle = FormBorderStyle.FixedDialog; // サイズ変更を無効化
+            MaximizeBox = false; // 最大化ボタンを無効化
+            StartPosition = FormStartPosition.CenterScreen; // 画面中央に表示
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(912, 573);
             Controls.Add(panel1);
             Margin = new Padding(2);
             Name = "ShowEmployeeInfoDetailForm";
@@ -449,5 +468,6 @@
         private Label lbl;
         private Label lblAppearEmployeeId;
         private Label lblAppearHireDate;
+        private TextBox notifyEmployeeRetired;
     }
 }

--- a/EmployeeManagementSystem/ShowEmployeeInfoForm.Designer.cs
+++ b/EmployeeManagementSystem/ShowEmployeeInfoForm.Designer.cs
@@ -30,13 +30,14 @@ namespace EmployeeManagementSystem
         /// </summary>
         private void InitializeComponent()
         {
-            DataGridViewCellStyle dataGridViewCellStyle1 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle2 = new DataGridViewCellStyle();
             panel1 = new Panel();
             txtErrorMessages = new TextBox();
             btnConfirm = new Button();
             btnLogout = new Button();
             btnShowEmployeeInfoDetail = new Button();
             areaSearch = new Panel();
+            chkRetired = new CheckBox();
             btnClear = new Button();
             btnSearch = new Button();
             txtKanaName = new TextBox();
@@ -69,6 +70,7 @@ namespace EmployeeManagementSystem
             // 
             // panel1
             // 
+            panel1.AutoScroll = true;
             panel1.AutoSize = true;
             panel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             panel1.BackColor = Color.Azure;
@@ -95,7 +97,7 @@ namespace EmployeeManagementSystem
             txtErrorMessages.Multiline = true;
             txtErrorMessages.Name = "txtErrorMessages";
             txtErrorMessages.ReadOnly = true;
-            txtErrorMessages.Size = new Size(354, 37);
+            txtErrorMessages.Size = new Size(516, 37);
             txtErrorMessages.TabIndex = 6;
             txtErrorMessages.Visible = false;
             // 
@@ -139,6 +141,7 @@ namespace EmployeeManagementSystem
             areaSearch.AutoSize = true;
             areaSearch.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             areaSearch.BorderStyle = BorderStyle.FixedSingle;
+            areaSearch.Controls.Add(chkRetired);
             areaSearch.Controls.Add(btnClear);
             areaSearch.Controls.Add(btnSearch);
             areaSearch.Controls.Add(txtKanaName);
@@ -151,15 +154,25 @@ namespace EmployeeManagementSystem
             areaSearch.Controls.Add(lblSelectOffice);
             areaSearch.Controls.Add(selectOffice);
             areaSearch.Controls.Add(selectPosition);
-            areaSearch.Location = new Point(401, 55);
+            areaSearch.Location = new Point(344, 55);
             areaSearch.Margin = new Padding(2);
             areaSearch.Name = "areaSearch";
-            areaSearch.Size = new Size(799, 109);
+            areaSearch.Size = new Size(928, 111);
             areaSearch.TabIndex = 2;
+            // 
+            // chkRetired
+            // 
+            chkRetired.AutoSize = true;
+            chkRetired.Location = new Point(14, 10);
+            chkRetired.Name = "chkRetired";
+            chkRetired.Size = new Size(76, 24);
+            chkRetired.TabIndex = 12;
+            chkRetired.Text = "退職済";
+            chkRetired.UseVisualStyleBackColor = true;
             // 
             // btnClear
             // 
-            btnClear.Location = new Point(705, 30);
+            btnClear.Location = new Point(834, 32);
             btnClear.Margin = new Padding(2);
             btnClear.Name = "btnClear";
             btnClear.Size = new Size(90, 27);
@@ -169,7 +182,7 @@ namespace EmployeeManagementSystem
             // 
             // btnSearch
             // 
-            btnSearch.Location = new Point(705, 78);
+            btnSearch.Location = new Point(834, 75);
             btnSearch.Margin = new Padding(2);
             btnSearch.Name = "btnSearch";
             btnSearch.Size = new Size(90, 27);
@@ -180,7 +193,7 @@ namespace EmployeeManagementSystem
             // txtKanaName
             // 
             txtKanaName.BorderStyle = BorderStyle.FixedSingle;
-            txtKanaName.Location = new Point(498, 78);
+            txtKanaName.Location = new Point(615, 80);
             txtKanaName.Margin = new Padding(2);
             txtKanaName.Name = "txtKanaName";
             txtKanaName.Size = new Size(184, 27);
@@ -189,7 +202,7 @@ namespace EmployeeManagementSystem
             // txtName
             // 
             txtName.BorderStyle = BorderStyle.FixedSingle;
-            txtName.Location = new Point(498, 43);
+            txtName.Location = new Point(615, 44);
             txtName.Margin = new Padding(2);
             txtName.Name = "txtName";
             txtName.Size = new Size(184, 27);
@@ -198,7 +211,7 @@ namespace EmployeeManagementSystem
             // txtEmployeeId
             // 
             txtEmployeeId.BorderStyle = BorderStyle.FixedSingle;
-            txtEmployeeId.Location = new Point(498, 8);
+            txtEmployeeId.Location = new Point(615, 10);
             txtEmployeeId.Margin = new Padding(2);
             txtEmployeeId.Name = "txtEmployeeId";
             txtEmployeeId.Size = new Size(184, 27);
@@ -207,7 +220,7 @@ namespace EmployeeManagementSystem
             // lblSearchKanaName
             // 
             lblSearchKanaName.AutoSize = true;
-            lblSearchKanaName.Location = new Point(416, 80);
+            lblSearchKanaName.Location = new Point(518, 82);
             lblSearchKanaName.Margin = new Padding(2, 0, 2, 0);
             lblSearchKanaName.Name = "lblSearchKanaName";
             lblSearchKanaName.Size = new Size(94, 20);
@@ -217,7 +230,7 @@ namespace EmployeeManagementSystem
             // lblSearchName
             // 
             lblSearchName.AutoSize = true;
-            lblSearchName.Location = new Point(416, 48);
+            lblSearchName.Location = new Point(565, 48);
             lblSearchName.Margin = new Padding(2, 0, 2, 0);
             lblSearchName.Name = "lblSearchName";
             lblSearchName.Size = new Size(39, 20);
@@ -227,7 +240,7 @@ namespace EmployeeManagementSystem
             // lblSearchEmployeeId
             // 
             lblSearchEmployeeId.AutoSize = true;
-            lblSearchEmployeeId.Location = new Point(416, 13);
+            lblSearchEmployeeId.Location = new Point(538, 16);
             lblSearchEmployeeId.Margin = new Padding(2, 0, 2, 0);
             lblSearchEmployeeId.Name = "lblSearchEmployeeId";
             lblSearchEmployeeId.Size = new Size(69, 20);
@@ -237,7 +250,7 @@ namespace EmployeeManagementSystem
             // lblSelectPosition
             // 
             lblSelectPosition.AutoSize = true;
-            lblSelectPosition.Location = new Point(205, 11);
+            lblSelectPosition.Location = new Point(335, 14);
             lblSelectPosition.Margin = new Padding(2, 0, 2, 0);
             lblSelectPosition.Name = "lblSelectPosition";
             lblSelectPosition.Size = new Size(39, 20);
@@ -247,7 +260,7 @@ namespace EmployeeManagementSystem
             // lblSelectOffice
             // 
             lblSelectOffice.AutoSize = true;
-            lblSelectOffice.Location = new Point(14, 11);
+            lblSelectOffice.Location = new Point(128, 11);
             lblSelectOffice.Margin = new Padding(2, 0, 2, 0);
             lblSelectOffice.Name = "lblSelectOffice";
             lblSelectOffice.Size = new Size(39, 20);
@@ -257,7 +270,7 @@ namespace EmployeeManagementSystem
             // selectOffice
             // 
             selectOffice.FormattingEnabled = true;
-            selectOffice.Location = new Point(54, 9);
+            selectOffice.Location = new Point(169, 9);
             selectOffice.Margin = new Padding(2);
             selectOffice.Name = "selectOffice";
             selectOffice.Size = new Size(146, 28);
@@ -266,7 +279,7 @@ namespace EmployeeManagementSystem
             // selectPosition
             // 
             selectPosition.FormattingEnabled = true;
-            selectPosition.Location = new Point(248, 10);
+            selectPosition.Location = new Point(377, 11);
             selectPosition.Margin = new Padding(2);
             selectPosition.Name = "selectPosition";
             selectPosition.Size = new Size(146, 28);
@@ -278,14 +291,14 @@ namespace EmployeeManagementSystem
             dataGridViewEmployee.AllowUserToDeleteRows = false;
             dataGridViewEmployee.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             dataGridViewEmployee.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
-            dataGridViewCellStyle1.Alignment = DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = Color.Blue;
-            dataGridViewCellStyle1.Font = new Font("メイリオ", 10F, FontStyle.Bold);
-            dataGridViewCellStyle1.ForeColor = Color.White;
-            dataGridViewCellStyle1.SelectionBackColor = SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = DataGridViewTriState.True;
-            dataGridViewEmployee.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle2.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = Color.Blue;
+            dataGridViewCellStyle2.Font = new Font("メイリオ", 10F, FontStyle.Bold);
+            dataGridViewCellStyle2.ForeColor = Color.White;
+            dataGridViewCellStyle2.SelectionBackColor = SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = DataGridViewTriState.True;
+            dataGridViewEmployee.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
             dataGridViewEmployee.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dataGridViewEmployee.Columns.AddRange(new DataGridViewColumn[] { employee_id, first_name, last_name, kana_first_name, kana_last_name, mail, phone_num, hire_date, office_name, position_name, status });
             dataGridViewEmployee.EditMode = DataGridViewEditMode.EditOnEnter;
@@ -294,7 +307,7 @@ namespace EmployeeManagementSystem
             dataGridViewEmployee.Margin = new Padding(2);
             dataGridViewEmployee.Name = "dataGridViewEmployee";
             dataGridViewEmployee.RowHeadersWidth = 62;
-            dataGridViewEmployee.Size = new Size(1304, 514);
+            dataGridViewEmployee.Size = new Size(panel1.Width - 10, panel1.Height - 100);
             dataGridViewEmployee.TabIndex = 1;
             // 
             // employee_id
@@ -451,5 +464,6 @@ namespace EmployeeManagementSystem
         private DataGridViewTextBoxColumn position_name;
         private DataGridViewTextBoxColumn status;
         private TextBox txtErrorMessages;
+        private CheckBox chkRetired;
     }
 }

--- a/EmployeeManagementSystem/Utils/CloseFormHelper.cs
+++ b/EmployeeManagementSystem/Utils/CloseFormHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmployeeManagementSystem.Utils
+{
+    public static class CloseFormHelper
+    {
+        public static void CloseSpecificForm(string formNameToExclude)
+        {
+            Form loginForm = null; // LoginFormインスタンスを保持する変数
+
+            // Invokeを使用してUIスレッド上で操作を実行
+            if (Application.OpenForms[0].InvokeRequired)
+            {
+                Application.OpenForms[0].Invoke((Action)(() =>
+                {
+                    // フォームの列挙と処理
+                    for (int i = Application.OpenForms.Count - 1; i >= 0; i--)
+                    {
+                        var form = Application.OpenForms[i];
+                        if (form != null)
+                        {
+                            if (form.Name == formNameToExclude) // LoginFormを保持
+                            {
+                                loginForm = form;
+                            }
+                            else
+                            {
+                                form.Close(); // 他のフォームを閉じる
+                            }
+                        }
+                    }
+
+                    // LoginFormが見つかれば再表示
+                    loginForm?.Show();
+                }));
+            }
+            else
+            {
+                // UIスレッドで処理を実行
+                for (int i = Application.OpenForms.Count - 1; i >= 0; i--)
+                {
+                    var form = Application.OpenForms[i];
+                    if (form != null)
+                    {
+                        if (form.Name == formNameToExclude) // LoginFormを保持
+                        {
+                            loginForm = form;
+                        }
+                        else
+                        {
+                            form.Close(); // 他のフォームを閉じる
+                        }
+                    }
+                }
+
+                // LoginFormが見つかれば再表示
+                loginForm?.Show();
+            }
+        }
+
+    }
+}

--- a/EmployeeManagementSystem/Utils/ErrorMessages.cs
+++ b/EmployeeManagementSystem/Utils/ErrorMessages.cs
@@ -9,5 +9,69 @@ namespace EmployeeManagementSystem.Utils
     public static class ErrorMessages
     {
         public const string ERR001_EMPTY_FIELD = "空白の項目があります。";
+
+        public const string ERR002_KANA_FIRST_NAME_LIMIT  = "姓（かな）は25文字以内で入力してください。";
+
+        public const string ERR003_INPUT_HIRAGANA_ONLY = "平仮名のみ入力してください。";
+
+        public const string ERR004_MISSING_KANA_FIRST_NAME = "姓（かな）は入力必須です。";
+
+        public const string ERR005_KANA_LAST_NAME_LIMIT = "名（かな）は25文字以内で入力してください。";
+
+        public const string ERR006_MISSING_KANA_LAST_NAME = "名（かな）は入力必須です。";
+
+        public const string ERR007_FIRST_NAME_LIMIT = "姓 は25文字以内で入力してください。";
+
+        public const string ERR008_MISSING_FIRST_NAME = "姓 は入力必須です。";
+
+        public const string ERR009_LAST_NAME_LIMIT = "名 は25文字以内で入力してください。";
+
+        public const string ERR010_MISSING_LAST_NAME = "名 は入力必須です。";
+
+        public const string ERR011_MISSING_MAIL = "メールアドレス は入力必須です。";
+
+        public const string ERR012_REQUIRED_VALID_MAIL = "有効なメールアドレスを入力してください。";
+
+        public const string ERR013_MISSING_PHONE_NUM = "電話番号 は入力必須です。";
+
+        public const string ERR014_REQUIRED_VALID_PHONE_NUM = "電話番号は「080-1234-5678」の形式で入力してください。";
+
+        public const string ERR015_MISSING_OFFICE = "拠点 は入力必須です。";
+
+        public const string ERR016_LOCATION_NAME_INCORRECT = "拠点名が間違っています。";
+
+        public const string ERR017_MISSING_POSITION = "役職 は入力必須です。";
+
+        public const string ERR018_POSITION_NAME_INCORRECT = "役職名が間違っています。";
+
+        public const string ERR019_DATABASE_READ_ERROR = "データの読み込み中にエラーが発生しました:";
+
+        public const string ERR020_ERROR_DURING_SEARCH = "検索中にエラーが発生しました:";
+
+        public const string ERR021_DATE_MUST_BE_PAST_OR_PRESENT = "日付は現在以前である必要があります。";
+
+        public const string ERR022_MISSING_PASSWORD_AND_MAIL = "メールアドレスとパスワードを入力してください。";
+
+        public const string ERR022_REQUIRED_VALID_PASSWORD_AND_MAIL = "メールアドレスまたはパスワードが正しくありません。";
+
+        public const string ERR024_REQUIRED_VALID_EMPLOYEE_IDS = "検索エリアの社員番号に、[数字][半角スペース][カンマ( , )]以外入力しないでください";
+
+        public const string ERR025_OVERFLOW_NUMBER = "範囲を超える値が入力されています。正しい社員番号を入力してください。";
+
+        public const string ERR026_HAVING_INPUT_ERROR = "入力エラーがあります。修正してください。";
+
+        public const string ERR027_STATUS_UPDATE_ERROR = "ステータス更新中にエラーが発生しました:";
+
+        public const string ERR028_DELETE_FAILED = "削除が失敗しました。";
+
+        public const string ERR029_NOT_FIND_EMPLOYEE = "該当する社員のデータが見つかりません。";
+
+        public const string ERR030_DATA_SAVE_ERROR = "データの保存中にエラーが発生しました:";
+
+        public const string ERR031_DATA_UPDATE_ERROR = "更新中にエラーが発生しました:";
+
+        public const string ERR032_COULD_NOT_UPDATE = "データの更新ができませんでした。\n入力した内容をご確認ください。";
+
+
     }
 }

--- a/EmployeeManagementSystem/Utils/InformationMessages.cs
+++ b/EmployeeManagementSystem/Utils/InformationMessages.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmployeeManagementSystem.Utils
+{
+    public static class InformationMessages
+    {
+        public const string INFO001_NOTIFY_EMPLOYEE_RETIRED = "現在表示されている社員は退職済みです。";
+
+        public const string INFO002_NOTIFY_SESSION_TIMEOUT = "セッションがタイムアウトしました。";
+
+        public const string INFO003_CANCEL_CONFIRMATION = "本当にキャンセルしてもよろしいですか？";
+
+        public const string INFO004_DELETE_CONFIRMATION = "本当に削除しますか？（ステータスが変更されます）";
+
+        public const string INFO005_DELETE_SUCCESS = "削除されました。";
+
+        public const string INFO006_UPDATE_CONFIRMATION = "本当に更新してもよろしいですか？";
+
+        public const string INFO007_UPDATE_SUCCESS = "データが更新されました。";
+
+        public const string INFO008_NOTIFY_NO_CHANGE = "変更がありません。";
+
+        public const string INFO009_ADD_CONFIRMATION = "本当に登録してもよろしいですか？";
+
+        public const string INFO010_SAVE_SUCCESS = "データが正常に保存されました。";
+
+        public const string INFO011_LOGOUT_CONFIRMATION = "本当にログアウトしてもよろしいですか？";
+
+
+
+
+        public const string TITLE001_CONFIRMATION = "確認";
+
+        public const string TITLE002_ERROR = "エラー";
+
+        public const string TITLE003_SESSION_TIMEOUT = "セッションタイムアウト";
+
+        public const string TITLE004_INPUT_ERROR = "入力エラー";
+
+        public const string TITLE005_DELETED = "削除成功";
+
+        public const string TITLE006_UPDATED = "更新成功";
+
+        public const string TITLE007_ATTENTION = "注意";
+
+        public const string TITLE008_UPDATE_FAILED = "更新失敗";
+
+        public const string TITLE009_SAVED = "保存成功";
+
+        public const string TITLE010_AUTHENTICATION_ERROR = "認証エラー";
+    } 
+}

--- a/EmployeeManagementSystem/Utils/SessionManager.cs
+++ b/EmployeeManagementSystem/Utils/SessionManager.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EmployeeManagementSystem.Contexts;
+using EmployeeManagementSystem.DataModel;
+using System.Timers;
+using Timer = System.Timers.Timer;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+
+namespace EmployeeManagementSystem.Utils
+{
+    public static class SessionManager
+    {
+        public static int session_id { get; set; } // セッションID（主キー）
+
+        public static int employee_id { get; set; } // 社員ID（外部キー）
+
+        public static DateTime? login_time { get; set; } // ログイン時間
+
+        public static DateTime? logout_time { get; set; } // ログアウト時間（null可能）
+
+        public static string session_token { get; set; } // セッショントークン
+
+        public static string ip_address { get; set; } // IPアドレス
+
+        public static string user_agent { get; set; } // ブラウザ・デバイス情報
+
+        public static bool is_active { get; set; } // アクティブ状態（1: アクティブ, 0: 非アクティブ）
+
+
+        // タイムアウト時間（30分）
+        private static Timer sessionTimer;
+        private static readonly int TimeoutDurationInMinutes = 30;
+
+        public static void StartSession()
+        {
+            // タイマーを初期化
+            sessionTimer = new Timer(TimeoutDurationInMinutes * 60 * 1000); // ミリ秒で指定
+            //sessionTimer = new Timer(10 * 1000); // 30秒で指定(テスト用）
+            sessionTimer.Elapsed += OnSessionTimeout;
+            sessionTimer.AutoReset = false;
+            sessionTimer.Start();
+        }
+
+
+        private static void OnSessionTimeout(object sender, ElapsedEventArgs e)
+        {
+            MessageBox.Show(InformationMessages.INFO002_NOTIFY_SESSION_TIMEOUT, InformationMessages.TITLE003_SESSION_TIMEOUT, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            SetLogoutTime();
+            Session_Clear();
+
+            // ログインフォーム以外をすべて閉じる
+            CloseFormHelper.CloseSpecificForm("LoginForm");
+
+        }
+
+        public static void SetLogoutTime()
+        {
+            logout_time = DateTime.Now;
+
+            using (var dbContext = new EmployeeManagementSystemContext())
+            {
+                try
+                {
+
+                    var SessionRecord = dbContext.Session
+                        .Where(s => s.session_id == session_id) // 条件指定
+                        .FirstOrDefault(); // 最初のレコードを取得
+                                           
+                    if (SessionRecord != null)
+                    {
+                        // logout_timeを更新
+                        SessionRecord.logout_time = logout_time;
+                        SessionRecord.is_active = false;
+
+                        // データベースに保存
+                        dbContext.SaveChanges();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // 例外処理
+                    //MessageBox.Show($"{ErrorMessages.ERR019_DATABASE_READ_ERROR} {ex.Message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        public static void Session_Clear()
+        {
+            session_id = 0;
+            employee_id = 0;
+            login_time = null;
+            logout_time = null;
+            session_token = null;
+            ip_address = null;
+            user_agent = null;
+            is_active = false;
+        }
+
+
+    }
+}


### PR DESCRIPTION
※編集PCの環境 SQL：mySQL
以下、追加・変更内容
・AddEmployeeInfoForm.cs
[変更]メッセージ、ダイアログタイトルバーメッセージをUtilフォルダーのErrorMessagesまたはInformationクラスから取得して表示 [追加]追加ボタン押下時、確認ダイアログ表示
[追加]クリアボタン押下時エラーメッセージが表示されている場合、そのエラーをクリアする

・EmployeeManagementSystemContext.cs
[追加]Sessionテーブル追加に伴い、コンテキストに追加

・EmployeeModel.cs
[追加]EmployeeテーブルとSessionテーブルのリレーションを追加

・LoginForm.Designer.cs
[追加]パスワードの網掛プロパティ
[追加]最大化ボタンを非活性にするプロパティ
[変更]ユーザーがダイアログウィンドウのサイズを変更できないよう設定

・LoginForm.cs
[変更]LoginFormコンストラクタから画面のデザインに関する記述と、ボタンクリック時の関数を排除し、メソッドを呼び出すだけの記述を記載 [追加]ログイン成功時Sessionデータを作成
[追加]入力値チェック

・LoginForm.ja-JP.resx
・LoginForm.resx
[変更]画面の表示設定

・ShowEmployeeInfoDetailForm.Designer.cs
[追加]退職済社員を表示する場合、それを知らせるテキストボックス

・ShowEmployeeInfoDetailForm.cs
[変更]ShowEmployeeInfoDetailFormコンストラクタからフォームのデザインに関する記述を排除 [変更]メッセージ、ダイアログタイトルバーメッセージをUtilフォルダーのErrorMessagesまたはInformationクラスから取得して表示 [追加]退職済社員を表示する場合、更新と削除ボタン、テキストボックス非活性化
[追加]更新ボタン押下時、確認ダイアログ表示

・ShowEmployeeInfoForm.Designer.cs
[追加]検索エリアに退職済みチェックボックス

・ShowEmployeeInfoForm.cs
[追加]社員番号をカンマまたは半角スペース区切りで複数検索可
[追加]デフォルトで退職済社員を非表示にし、検索エリアのチェックボックスのチェックを入れると表示可
[追加]退職済社員の検索結果の編集を不可にする
[追加]検索結果編集後、更新する場合の入力チェック
[追加]グリッドの社員番号ヘッダークリックで社員番号の昇順、降順表示可
[追加]ログアウトボタン押下時、その時のセッションIDのlogout_timeにログアウトした時間を登録し、セッション情報をクリアにする [追加]ログアウトボタンを押下せずフォームを消したとき、その時のセッションIDのlogout_timeにログアウトした時間を登録し、セッション情報をクリアにし、隠していたログイン画面を再表示する

・ErrorMessages.cs
[追加]エラーメッセージの追加

・SessionModel.cs
[追加]Sessionテーブルのデータモデル

・CloseFormHelper.cs
[追加]セッションタイムアウト時ログイン画面以外を閉じ、隠していたログイン画面を再表示

・InformationMessages.cs
[追加]情報メッセージ、ダイアログタイトルバーメッセージ情報

・SessionManager.cs
[追加]セッション情報保持するゲッターとセッター
[追加]セッションタイムアウト時間の設定とタイムアウト時、ログアウトするメソッド
[追加]ログアウト時の時間をDBに登録
[追加]ログアウト時セッション情報をクリアするメソッド