### PR TITLE
2025/04/30 変更

### DIFF
--- a/EmployeeManagementSystem/AddEmployeeInfoForm.cs
+++ b/EmployeeManagementSystem/AddEmployeeInfoForm.cs
@@ -102,10 +102,10 @@ namespace EmployeeManagementSystem
                 errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR006_MISSING_KANA_LAST_NAME);
                 isValid = false;
             }
-            else if (txtKanaFirstName.Text.Length > 25)
+            else if (txtKanaLastName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR005_KANA_LAST_NAME_LIMIT);
+                errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR005_KANA_LAST_NAME_LIMIT);
                 isValid = false;
             }
             else if (!System.Text.RegularExpressions.Regex.IsMatch(txtKanaLastName.Text, @"^[\u3041-\u3096ー]+$"))

--- a/EmployeeManagementSystem/ShowEmployeeInfoDetailForm.cs
+++ b/EmployeeManagementSystem/ShowEmployeeInfoDetailForm.cs
@@ -415,10 +415,10 @@ namespace EmployeeManagementSystem
                 errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR006_MISSING_KANA_LAST_NAME);
                 isValid = false;
             }
-            else if (txtKanaFirstName.Text.Length > 25)
+            else if (txtKanaLastName.Text.Length > 25)
             {
                 // 文字数超過の場合のエラー設定
-                errorProvider.SetError(txtKanaFirstName, ErrorMessages.ERR005_KANA_LAST_NAME_LIMIT);
+                errorProvider.SetError(txtKanaLastName, ErrorMessages.ERR005_KANA_LAST_NAME_LIMIT);
                 isValid = false;
             }
             else if (!System.Text.RegularExpressions.Regex.IsMatch(txtKanaLastName.Text, @"^[\u3041-\u3096ー]+$"))


### PR DESCRIPTION
・AddEmployeeInfoForm.cs
・ShowEmployeeInfoDetailForm.cs
[変更]名（かな）の文字数制限バリデーションで、コントロール名の記述ミスがあり修正。
[変更][追加]退職済の社員の編集可能項目が「不可」でなければならないのに「可」となってしまったため修正。 [変更][追加]グリッド検索結果を編集し、確定ボタン押下後ヴァリデーションが偽の場合に表示されるエラーメッセージが、検索ボタンを押下したときに消えるよう修正。 [変更][追加]検索条件を付与し検索後、グリッドの社員番号ヘッダークリックすると、退職済社員以外の情報が表示されてしまうため、検索条件を付与したとき、グリッドの社員番号ヘッダーをクリックしたときのソートするためのメソッドが実行されないよう修正。